### PR TITLE
use new RELEASE statusChangeCommand type instead of hardcoded FREE status, when releasing objects

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -378,11 +378,11 @@ func (events *Events) HoldBestAvailable(eventKey string, params BestAvailablePar
 }
 
 func (events *Events) Release(eventKey string, objectIds ...string) (*ChangeObjectStatusResult, error) {
-	return events.releaseStatus(eventKey, events.toObjectProperties(objectIds), nil)
+	return events.releaseObjects(eventKey, events.toObjectProperties(objectIds), nil)
 }
 
 func (events *Events) ReleaseWithHoldToken(eventKey string, objectIds []string, holdToken *string) (*ChangeObjectStatusResult, error) {
-	return events.releaseStatus(eventKey, events.toObjectProperties(objectIds), holdToken)
+	return events.releaseObjects(eventKey, events.toObjectProperties(objectIds), holdToken)
 }
 
 func (events *Events) ReleaseWithOptions(statusChangeParams *StatusChangeParams) (*ChangeObjectStatusResult, error) {
@@ -390,7 +390,7 @@ func (events *Events) ReleaseWithOptions(statusChangeParams *StatusChangeParams)
 	return events.ChangeObjectStatusWithOptions(statusChangeParams)
 }
 
-func (events *Events) releaseStatus(eventKey string, objectProperties []ObjectProperties, holdToken *string) (*ChangeObjectStatusResult, error) {
+func (events *Events) releaseObjects(eventKey string, objectProperties []ObjectProperties, holdToken *string) (*ChangeObjectStatusResult, error) {
 	params := StatusChangeParams{
 		Events: []string{eventKey},
 		StatusChanges: StatusChanges{

--- a/events/events.go
+++ b/events/events.go
@@ -69,7 +69,8 @@ const (
 )
 
 type StatusChanges struct {
-	Status                   ObjectStatus       `json:"status"`
+	Type                     string             `json:"type,omitempty"`
+	Status                   ObjectStatus       `json:"status,omitempty"`
 	Objects                  []ObjectProperties `json:"objects"`
 	HoldToken                string             `json:"holdToken,omitempty"`
 	OrderId                  string             `json:"orderId,omitempty"`
@@ -377,16 +378,30 @@ func (events *Events) HoldBestAvailable(eventKey string, params BestAvailablePar
 }
 
 func (events *Events) Release(eventKey string, objectIds ...string) (*ChangeObjectStatusResult, error) {
-	return events.changeStatus(FREE, eventKey, events.toObjectProperties(objectIds), nil)
+	return events.releaseStatus(eventKey, events.toObjectProperties(objectIds), nil)
 }
 
 func (events *Events) ReleaseWithHoldToken(eventKey string, objectIds []string, holdToken *string) (*ChangeObjectStatusResult, error) {
-	return events.changeStatus(FREE, eventKey, events.toObjectProperties(objectIds), holdToken)
+	return events.releaseStatus(eventKey, events.toObjectProperties(objectIds), holdToken)
 }
 
 func (events *Events) ReleaseWithOptions(statusChangeParams *StatusChangeParams) (*ChangeObjectStatusResult, error) {
-	statusChangeParams.Status = FREE
+	statusChangeParams.Type = "RELEASE"
 	return events.ChangeObjectStatusWithOptions(statusChangeParams)
+}
+
+func (events *Events) releaseStatus(eventKey string, objectProperties []ObjectProperties, holdToken *string) (*ChangeObjectStatusResult, error) {
+	params := StatusChangeParams{
+		Events: []string{eventKey},
+		StatusChanges: StatusChanges{
+			Type:    "RELEASE",
+			Objects: objectProperties,
+		},
+	}
+	if holdToken != nil {
+		params.HoldToken = *holdToken
+	}
+	return events.ChangeObjectStatusWithOptions(&params)
 }
 
 func (events *Events) changeStatus(status ObjectStatus, eventKey string, objectProperties []ObjectProperties, holdToken *string) (*ChangeObjectStatusResult, error) {


### PR DESCRIPTION
Instead of passing in FREE as a status, we now use RELEASE as statusChangeCommand type.
That way, objects that were in RESALE status before, will be released to status RESALE, and not to FREE.