### PR TITLE
Remove update chart key for event

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -32,8 +32,7 @@ type CreateMultipleEventParams struct {
 }
 
 type UpdateEventParams struct {
-	ChartKey    *string `json:"chartKey,omitempty"`
-	IsInThePast *bool   `json:"isInThePast,omitempty"`
+	IsInThePast *bool `json:"isInThePast,omitempty"`
 	*EventParams
 }
 

--- a/events_test/update_event_test.go
+++ b/events_test/update_event_test.go
@@ -11,25 +11,6 @@ import (
 	"time"
 )
 
-func TestUpdateEventChartKey(t *testing.T) {
-	t.Parallel()
-	company := test_util.CreateTestCompany(t)
-	chartKey := test_util.CreateTestChart(t, company.Admin.SecretKey)
-	chartKey2 := test_util.CreateTestChart(t, company.Admin.SecretKey)
-	client := seatsio.NewSeatsioClient(test_util.BaseUrl, company.Admin.SecretKey)
-	event, err := client.Events.Create(&events.CreateEventParams{ChartKey: chartKey})
-	require.NoError(t, err)
-
-	err = client.Events.Update(event.Key, &events.UpdateEventParams{
-		ChartKey: &chartKey2,
-	})
-	require.NoError(t, err)
-
-	updatedEvent, err := client.Events.Retrieve(event.Key)
-	require.NoError(t, err)
-	require.Equal(t, chartKey2, updatedEvent.ChartKey)
-}
-
 func TestUpdateEventEventKey(t *testing.T) {
 	t.Parallel()
 	company := test_util.CreateTestCompany(t)


### PR DESCRIPTION
Updating the chart key of an event is no longer documented but is still supported by the client libraries. This PR removes the parameter from `UpdateEventParams`.